### PR TITLE
Adding cli and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,16 @@ The views and opinions expressed in the following topics are based in my persona
     </td>
   </tr>
 </table>
+
+---
+
+### Adding a new post
+
+From the repo root, run:
+
+```bash
+npm install
+npx tsx cli.ts add --template <essay|concept|story|short>
+```
+
+Or use the short form: `npx tsx cli.ts add -t essay`. The CLI creates a new post from the chosen template with auto-generated placeholder data and updates `POSTS.md` and this README. Replace the title, date, and body content in the new post manually. Add `thumbnail.png` (and optionally `article-01.png`, `article-02.png`, etc.) to the post's `static/` folder so the post appears correctly in the index above.

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * CLI for adding new blog posts from templates.
+ * Usage: npx tsx cli.ts add --template <essay|concept|story|short>
+ */
+
+import { Command } from 'commander';
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import Mustache from 'mustache';
+
+// Don't escape HTML; we're rendering markdown, not HTML.
+Mustache.escape = (text: string) => text;
+
+const TEMPLATE_TYPES = ['essay', 'concept', 'story', 'short'] as const;
+type TemplateType = (typeof TEMPLATE_TYPES)[number];
+
+const LOREM_WORDS = [
+  'Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing', 'elit',
+  'sed', 'do', 'eiusmod', 'tempor', 'incididunt', 'ut', 'labore', 'et', 'dolore',
+  'magna', 'aliqua', 'enim', 'minim', 'veniam', 'quis', 'nostrud', 'exercitation',
+];
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+interface GeneratedPost {
+  title: string;
+  slug: string;
+  dateIso: string;
+  dateBadge: string;
+  dateDisplay: string;
+  readTime: number;
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function generateRandomTitle(): string {
+  const numWords = randomInt(2, 4);
+  const words: string[] = [];
+  for (let i = 0; i < numWords; i++) {
+    words.push(pick(LOREM_WORDS));
+  }
+  return words.join(' ');
+}
+
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function getExistingSlugs(root: string): Set<string> {
+  const slugs = new Set<string>();
+  if (!existsSync(root)) return slugs;
+  for (const name of readdirSync(root, { withFileTypes: true })) {
+    if (name.isDirectory() && !name.name.startsWith('.')) {
+      slugs.add(name.name);
+    }
+  }
+  const postsPath = join(root, 'POSTS.md');
+  if (existsSync(postsPath)) {
+    const content = readFileSync(postsPath, 'utf-8');
+    const idMatches = content.matchAll(/^- id: (.+)$/gm);
+    for (const m of idMatches) slugs.add(m[1].trim());
+  }
+  return slugs;
+}
+
+function ensureUniqueSlug(baseSlug: string, root: string): string {
+  const existing = getExistingSlugs(root);
+  let slug = baseSlug;
+  let n = 1;
+  while (existing.has(slug)) {
+    slug = `${baseSlug}-${n}`;
+    n++;
+  }
+  return slug;
+}
+
+function formatDateBadge(d: Date): string {
+  const month = MONTHS[d.getMonth()];
+  const day = d.getDate();
+  const year = d.getFullYear();
+  return `${month}/${day},%20${year}`;
+}
+
+function formatDateDisplay(d: Date): string {
+  const month = MONTHS[d.getMonth()];
+  const day = d.getDate();
+  const year = d.getFullYear();
+  return `${month} ${day}, ${year}`;
+}
+
+function generatePostData(root: string): GeneratedPost {
+  const title = generateRandomTitle();
+  const baseSlug = slugify(title) || `post-${Date.now()}`;
+  const slug = ensureUniqueSlug(baseSlug, root);
+  const d = new Date();
+  const dateIso = d.toISOString().slice(0, 10);
+  return {
+    title,
+    slug,
+    dateIso,
+    dateBadge: formatDateBadge(d),
+    dateDisplay: formatDateDisplay(d),
+    readTime: randomInt(3, 8),
+  };
+}
+
+function toMustacheView(data: GeneratedPost): Record<string, string | number> {
+  return {
+    TITLE: data.title,
+    SLUG: data.slug,
+    DATE_ISO: data.dateIso,
+    DATE_BADGE: data.dateBadge,
+    DATE_DISPLAY: data.dateDisplay,
+    READ_TIME: data.readTime,
+    READ_TIME_BADGE: data.readTime,
+  };
+}
+
+function renderTemplate(template: string, data: GeneratedPost): string {
+  return Mustache.render(template, toMustacheView(data));
+}
+
+function createPost(root: string, templateType: TemplateType, data: GeneratedPost): void {
+  const templatesDir = join(root, 'templates');
+  const templatePath = join(templatesDir, `${templateType}.md`);
+  const template = readFileSync(templatePath, 'utf-8');
+  const content = renderTemplate(template, data);
+
+  const postDir = join(root, data.slug);
+  const staticDir = join(postDir, 'static');
+  mkdirSync(staticDir, { recursive: true });
+  writeFileSync(join(postDir, 'README.md'), content, 'utf-8');
+  writeFileSync(
+    join(staticDir, 'README.md'),
+    'Add thumbnail.png here (and optionally article-01.png, article-02.png, etc.).\n',
+    'utf-8'
+  );
+}
+
+function prependPostBlock(root: string, data: GeneratedPost): void {
+  const postsPath = join(root, 'POSTS.md');
+  let content = readFileSync(postsPath, 'utf-8');
+  const titleForList = data.title;
+  const block = `
+## ${titleForList}
+
+- id: ${data.slug}
+- date: ${data.dateIso}
+- link: /posts/${data.slug}
+- readTime: ${data.readTime}
+`;
+  const afterHeader = content.indexOf('\n\n');
+  const insertAt = afterHeader >= 0 ? afterHeader + 2 : content.length;
+  content = content.slice(0, insertAt) + block.trimStart() + '\n\n' + content.slice(insertAt);
+  writeFileSync(postsPath, content, 'utf-8');
+}
+
+function buildNewTableHtml(data: GeneratedPost, repoName: string): string {
+  const badgeUrl =
+    'https://badgen.net/badge/' + data.readTime + '/min%20read/darkgray?scale=1&labelColor=darkgray&color=darkgray&cache=360000';
+  const baseUrl = 'https://github.com/' + repoName + '/blob/main';
+  const thumbnailSrc = './' + data.slug + '/static/thumbnail.png';
+  const linkHref = baseUrl + '/' + data.slug + '/README.md';
+  return (
+    '\n<table>\n  <tr>\n    <th width="33%">\n      <a href="' +
+    linkHref +
+    '">\n        <img alt="" src="' +
+    thumbnailSrc +
+    '"></img>\n      </a>\n    </th>\n  </tr>\n  <tr>\n    <td width="33%">\n      <a href="' +
+    linkHref +
+    '">\n        <br/>\n        <img alt="" src="' +
+    badgeUrl +
+    '" />\n        <br/>\n        ' +
+    data.title +
+    '\n      </a>\n      <br/>\n      <p>' +
+    data.dateDisplay +
+    '</p>\n    </td>\n  </tr>\n</table>\n'
+  );
+}
+
+function insertReadmeTable(root: string, data: GeneratedPost, repoName: string): void {
+  const readmePath = join(root, 'README.md');
+  let content = readFileSync(readmePath, 'utf-8');
+  const newTable = buildNewTableHtml(data, repoName);
+  content = content.trimEnd() + newTable;
+  writeFileSync(readmePath, content, 'utf-8');
+}
+
+
+function runAdd(templateType: TemplateType): void {
+  const root = process.cwd();
+  const data = generatePostData(root);
+  createPost(root, templateType, data);
+  prependPostBlock(root, data);
+  insertReadmeTable(root, data, 'alan-oliv/unstable-thought-diffusion');
+  console.log(`Created post: ${data.slug}`);
+  console.log(`  Title: ${data.title}`);
+  console.log(`  Date: ${data.dateDisplay}`);
+  console.log(`  Read time: ${data.readTime} min`);
+  console.log(`  Add thumbnail.png (and optional article-0N.png) to ${data.slug}/static/`);
+}
+
+const program = new Command();
+
+program
+  .name('cli')
+  .description('CLI for adding new blog posts from templates')
+  .version('1.0.0');
+
+program
+  .command('add')
+  .description('Create a new post from a template with auto-generated placeholder data')
+  .requiredOption(
+    '-t, --template <type>',
+    'Template type: essay | concept | story | short',
+    (value: string) => {
+      if (TEMPLATE_TYPES.includes(value as TemplateType)) return value as TemplateType;
+      throw new Error(`Template must be one of: ${TEMPLATE_TYPES.join(', ')}`);
+    }
+  )
+  .action((options: { template: TemplateType }) => {
+    runAdd(options.template);
+  });
+
+program.parse();

--- a/cli.ts
+++ b/cli.ts
@@ -262,17 +262,31 @@ program
 program
   .command('add')
   .description('Create a new post from a template')
-  .requiredOption(
+  .argument('[template]', 'Template type: essay | concept | story | short')
+  .argument('[title]', 'Post title (slug is derived from it)')
+  .option(
     '-t, --template <type>',
-    'Template type: essay | concept | story | short',
+    'Template type (same as first argument)',
     (value: string) => {
       if (TEMPLATE_TYPES.includes(value as TemplateType)) return value as TemplateType;
       throw new Error(`Template must be one of: ${TEMPLATE_TYPES.join(', ')}`);
     }
   )
-  .requiredOption('-n, --title <title>', 'Post title (slug is derived from it)')
-  .action((options: { template: TemplateType; title: string }) => {
-    runAdd(options.template, options.title);
+  .option('-n, --title <title>', 'Post title (same as second argument)')
+  .action((templateArg: string | undefined, titleArg: string | undefined, options: { template?: TemplateType; title?: string }) => {
+    const template = (options.template ?? templateArg) as TemplateType | undefined;
+    const title = options.title ?? titleArg;
+    if (!template || !TEMPLATE_TYPES.includes(template)) {
+      program.error(
+        'Template is required.\n  npm: npm run post:add -- essay "Your post title"\n  Or:  npx tsx cli.ts add -t essay -n "Your post title"'
+      );
+    }
+    if (!title?.trim()) {
+      program.error(
+        'Title is required.\n  npm: npm run post:add -- essay "Your post title"\n  Or:  npx tsx cli.ts add -t essay -n "Your post title"'
+      );
+    }
+    runAdd(template, title.trim());
   });
 
 program.parse();

--- a/musician-programmer/README.md
+++ b/musician-programmer/README.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/4/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # Musician programmer
 
 <img src="./static/article-01.png" align="right" width="50%"/>

--- a/mustache.d.ts
+++ b/mustache.d.ts
@@ -1,0 +1,4 @@
+declare module 'mustache' {
+  function render(template: string, view: object, partials?: object): string;
+  let escape: (text: string) => string;
+}

--- a/over-engineering-horror/README.md
+++ b/over-engineering-horror/README.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/5/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # The over-engineering horror
 
 <img src="./static/article-01.png" align="right" width="30%"/>
@@ -74,4 +72,5 @@ One quote I live by, not only in software engineering but in my essencialist/min
 Don't be a slave of your own creations. Don't be like Oliver.
 
 [^1]: [What is Occam's Razor?](https://math.ucr.edu/home/baez/physics/General/occam.html) - Attributed to the 14th century logician and Franciscan friar William of Ockham.
+
 [^2]: This quote is often attributed to Leonardo da Vinci. However, it is not clear till this day if he actually said or wrote this exact phrase.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,612 @@
+{
+  "name": "unstable-thought-diffusion",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unstable-thought-diffusion",
+      "version": "1.0.0",
+      "dependencies": {
+        "commander": "^12.0.0",
+        "mustache": "^4.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
+      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "mustache": "^4.2.0"
       },
       "devDependencies": {
+        "@types/mustache": "^4.2.6",
         "@types/node": "^20.10.0",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0"
@@ -458,6 +459,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@types/mustache": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.6.tgz",
+      "integrity": "sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.35",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mustache": "^4.2.0"
   },
   "devDependencies": {
+    "@types/mustache": "^4.2.6",
     "@types/node": "^20.10.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "unstable-thought-diffusion",
+  "version": "1.0.0",
+  "description": "Blog in MD format for GitHub",
+  "type": "module",
+  "scripts": {
+    "post:add": "tsx cli.ts add",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "commander": "^12.0.0",
+    "mustache": "^4.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/pair-less-programming/README.md
+++ b/pair-less-programming/README.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/2/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # Pair(less) programming
 
 I've been working remotely since 2016 and wouldn't trade it for anything.

--- a/solid-front-end/README.md
+++ b/solid-front-end/README.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/5/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # A solid front-end
 
 <img src="./static/article-01.png" align="right" width="55%"/>
@@ -108,4 +106,5 @@ Barbara Liskov introduced LSP 12 years before uncle bob said anything about SOLI
 The principles existed before they existed. (????)
 
 [^1]: "Les circuits de consécration sociale, sera d'autant plus efficace plus la distance sociale de l'objet consacrée" - Pierre Bourdieu
+
 [^2]: [Principles of OOD](http://www.butunclebob.com/ArticleS.UncleBob.PrinciplesOfOod) - Robert Martin (a.k.a Uncle Bob)

--- a/templates/concept.md
+++ b/templates/concept.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # {{TITLE}}
 
 <img src="./static/article-01.png" align="right" width="45%"/>
@@ -64,4 +62,5 @@ Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Good developers, as they gain experience, tend to naturally gravitate around these principles. The principles existed before they were named.
 
 [^1]: Lorem ipsum footnote one – reference or attribution.
+
 [^2]: [Lorem Ipsum Principles](https://example.com) – placeholder link for the acronym source.

--- a/templates/concept.md
+++ b/templates/concept.md
@@ -1,0 +1,67 @@
+<p>
+  <img alt="" src="https://badgen.net/badge/{{DATE_BADGE}}/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000"  />
+  <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
+</p>
+
+---
+
+# {{TITLE}}
+
+<img src="./static/article-01.png" align="right" width="45%"/>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris[^1].
+
+Since we are going to discuss the mnemonic _L.I.P.S.U.M_[^2], here is a short intro with lorem-style content for the reader.
+
+---
+
+_L.I.P.S.U.M_ stands for five placeholder concepts:
+
+1. **L**orem first principle
+2. **I**psum second principle
+3. **P**laceholder third principle
+4. **S**it amet fourth principle
+5. **U**t labore fifth principle
+
+Although the acronym is not purposely meant to mean "lorem" in the sense of being complete, following them can help you create content that is more consistent.
+
+---
+
+### First principle (lorem)
+
+> "There should never be more than one reason to change a certain module."
+
+Well, just keep it simple. I translate this as:
+
+> "Every component or module should do only ONE thing."
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Second principle (ipsum)
+
+> "Modules should be open for extension but closed for modification."
+
+I see this as:
+
+> "Allow a component to be flexible without hard-coding a lot of conditionals."
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+### Third principle (placeholder)
+
+> "Subtypes must be substitutable for their base types."
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem. In porttitor. Donec laoreet nonummy augue.
+
+### Fourth principle (conclusion)
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae. Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci.
+
+<img src="./static/article-02.png" width="100%"/>
+
+<br />
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Good developers, as they gain experience, tend to naturally gravitate around these principles. The principles existed before they were named.
+
+[^1]: Lorem ipsum footnote one – reference or attribution.
+[^2]: [Lorem Ipsum Principles](https://example.com) – placeholder link for the acronym source.

--- a/templates/essay.md
+++ b/templates/essay.md
@@ -1,0 +1,50 @@
+<p>
+  <img alt="" src="https://badgen.net/badge/{{DATE_BADGE}}/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000"  />
+  <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
+</p>
+
+# {{TITLE}}
+
+> "_Lorem ipsum dolor sit amet, consectetur adipiscing elit._"
+
+<img src="./static/article-01.png" width="100%"></img>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Curabitur pretium tincidunt lacus. Nulla facilisi. Phasellus convallis nulla vitae orci.
+
+---
+
+<img src="./static/article-02.png" align="left" width="39%"></img>
+
+### Lorem section one
+
+Maecenas fermentum consequat mi. Donec fermentum. Pellentesque malesuada nulla a mi. Duis sapien sem, aliquet nec, commodo eget, consequat quis, neque.
+
+Aliquam faucibus, elit ut dictum aliquet, felis nisl adipiscing risus, vitae porttitor orci magna eget massa. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci.
+
+> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.
+
+---
+
+<img src="./static/article-03.png" align="right" width="37%"></img>
+
+### Lorem section two
+
+Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci. Aenean nec lorem.
+
+In porttitor. Donec laoreet nonummy augue. Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Integer euismod lacus luctus magna. Quisque cursus, metus vitae pharetra auctor, sem massa mattis sem, at interdum magna augue eget diam.
+
+There is a tension here:
+
+- Between lorem and ipsum.
+- Between dolor and sit amet.
+- Between the past and the present.
+
+### How do we find that balance?
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci.
+
+---
+
+Maybe that's what lorem ipsum is really about. Not chasing brilliance, but clearing space for what truly matters.

--- a/templates/short.md
+++ b/templates/short.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # {{TITLE}}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/templates/short.md
+++ b/templates/short.md
@@ -1,0 +1,32 @@
+<p>
+  <img alt="" src="https://badgen.net/badge/{{DATE_BADGE}}/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000"  />
+  <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
+</p>
+
+---
+
+# {{TITLE}}
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Having more control over the work environment, finding the perfect balance, having more energy and fewer distractions are something that, for me, is beyond discussion.
+
+<img src="./static/article-01.png" align="left" width="35%" />
+
+You see, I was lucky enough to work with lorem and ipsum over the past few years; this allowed us to discuss, share ideas, and acquire knowledge. But, most of all, having fun doing what we love.
+
+_There's one thing, though, that became special: **lorem ipsum**._
+
+That's right, the simple technique where two concepts work together. I rarely work without it. This became natural and very organic.
+
+> "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+
+And I couldn't agree more. After all, we are part of the same community.
+
+---
+
+If you decide to give it a try, here are some useful links:
+
+- [Lorem Ipsum (example one)](https://example.com/one)
+- [Lorem Ipsum (example two)](https://example.com/two)
+- [Lorem Ipsum (example three)](https://example.com/three)

--- a/templates/story.md
+++ b/templates/story.md
@@ -3,8 +3,6 @@
   <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
 </p>
 
----
-
 # {{TITLE}}
 
 <img src="./static/article-01.png" align="right" width="30%"/>
@@ -58,4 +56,5 @@ One quote he lived by from that day forward:
 Don't be a slave of your own creations. Don't be like Marcus.
 
 [^1]: This quote is often attributed to Leonardo da Vinci. However, it is not clear to this day if he actually said or wrote this exact phrase.
+
 [^2]: [Lorem Ipsum](https://example.com) – a placeholder reference for the narrative.

--- a/templates/story.md
+++ b/templates/story.md
@@ -1,0 +1,61 @@
+<p>
+  <img alt="" src="https://badgen.net/badge/{{DATE_BADGE}}/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000"  />
+  <img alt="" src="https://badgen.net/badge/{{READ_TIME_BADGE}}/min%20read/darkgray?scale=1.1&labelColor=darkgray&color=darkgray&cache=360000" />
+</p>
+
+---
+
+# {{TITLE}}
+
+<img src="./static/article-01.png" align="right" width="30%"/>
+
+It was a dark and stormy night.
+
+Marcus was a lorem ipsum engineer. Always pushing the limits of what was possible through placeholder content, he decided to write the most elaborate document in history. He was not surprised when everyone told him he was crazy.
+
+But as it turned out, this was no easy task. As the storm raged outside, Marcus had spent countless hours drafting, editing, and revising. He poured every ounce of his energy into the project, determined to see it through to the end. He was obsessed with creating a masterpiece of lorem engineering.
+
+And in the end, Marcus was victorious. His one-page "Lorem Ipsum" draft was ready.
+
+---
+
+<img src="./static/article-02.png" width="100%"></img>
+
+---
+
+He tinkered with paragraphs and sections, desperate to get everything just right. Between lightnings and thunders, Marcus's document swelled to an unwieldy mass of complexity. He had to finish what he started.
+
+> "Maybe I could have made it simpler but it's too late - I just CAN'T throw all those words away, there's no comeback".
+
+He thought.
+
+Despite his best efforts, Marcus's readers refused to stay, leaving one after another in despair. Defeated and exhausted, Marcus slumped back in his chair and gazed at the screen. It was then that the irony of the situation dawned on him.
+
+---
+
+<img src="./static/article-03.png" align="right" width="43%"/>
+
+### The reckoning
+
+The paragraphs and sections of his document began to stir and come to life. And before Marcus knew it, he was surrounded by a group of angry sentences, blaming him for their existence.
+
+Panicked, Marcus tried to run, but it was too late. The words had him surrounded, and they were determined to make him pay.
+
+---
+
+<img src="./static/article-04.png" align="left" width="35%"/>
+
+### He became a shadow of his former self.
+
+Burned out and weak, Marcus, with his eyes lifted to the sky, was now a broken writer.
+
+He was also a survivor. Marcus learned a valuable lesson about the dangers of over-writing. He vowed to never make the same mistake again, and to always remember the power of simplicity in prose and in life as well.
+
+One quote he lived by from that day forward:
+
+> "Simplicity is the ultimate sophistication"[^1] - _Unknown_
+
+Don't be a slave of your own creations. Don't be like Marcus.
+
+[^1]: This quote is often attributed to Leonardo da Vinci. However, it is not clear to this day if he actually said or wrote this exact phrase.
+[^2]: [Lorem Ipsum](https://example.com) – a placeholder reference for the narrative.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["cli.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

This PR introduces a CLI tool and a set of Markdown templates to streamline the process of adding new blog posts to the repository. Instead of manually creating folders, writing boilerplate Markdown, and updating index files, authors can now run a single command to scaffold a new post from a chosen template — with all metadata, placeholder images, and index entries generated automatically.

## Changes

- Added a `cli.ts` powered by Commander that supports creating new posts via `npx tsx cli.ts add <template> "Post title"` (or equivalent flag-based syntax `-t` / `-n`)
- Introduced four Mustache-based Markdown templates (`essay`, `concept`, `story`, `short`) covering different post formats and layouts
- The CLI auto-generates post metadata (slug, date badge, read time), creates the post directory with a `static/` subfolder, and inserts placeholder images via dummyimage.com
- On post creation, `POSTS.md` is automatically updated with a new entry block prepended at the top